### PR TITLE
removed the ext struct for automatad's adapter

### DIFF
--- a/openrtb_ext/imp_automatad.go
+++ b/openrtb_ext/imp_automatad.go
@@ -1,6 +1,1 @@
 package openrtb_ext
-
-type ImpExtAutomatad struct {
-	Position    string `json:"position"`
-	PlacementID string `json:"placementId"`
-}


### PR DESCRIPTION
removed the ext struct for automatad's adapter since all bidder params are optional.